### PR TITLE
Optimized PairingHeap.Extract

### DIFF
--- a/pairing-heap-csharp/PairingHeap.cs
+++ b/pairing-heap-csharp/PairingHeap.cs
@@ -107,39 +107,30 @@ namespace pairing_heap_csharp
 
         private PairingNode<T> Extract(PairingNode<T> node)
         {
-            var children = new List<PairingNode<T>>();
+            if (node.Child is null)
+                return null;
+
+            PairingNode<T> result = null;
 
             var n = node.Child;
             while (!object.ReferenceEquals(n, null))
             {
+                if (n.Sibling is null)
+                    return Link(result, n);
+
                 var pair = n.Sibling;
                 n.Parent = null;
                 n.Sibling = null;
-                if (object.ReferenceEquals(pair, null))
-                {
-                    children.Add(n);
-                    break;
-                }
 
                 var next = pair.Sibling;
                 pair.Parent = null;
                 pair.Sibling = null;
-                children.Add(Link(n, pair));
+                result = Link(result, Link(n, pair));
+
                 n = next;
             }
 
-            if (children.Count == 0)
-            {
-                return null;
-            }
-
-            var root = children[0];
-            for (var i = 1; i < children.Count; ++i)
-            {
-                root = Link(root, children[i]);
-            }
-
-            return root;
+            return result;
         }
 
         public int Count


### PR DESCRIPTION
Optimized PairingHeap.Extract to the following effect:
- Code shortened
- Execution time reduced
- Memory allocation eliminated

Benchmarked these changes with BenchmarkDotNet in .NET 6 in a different project:
Original Method:  261.6 us
Updated Method:  184.1 us

The benchmark consisted of inserting 1,000 random numbers, then extracting them all.

All tests pass.